### PR TITLE
Changed Instrumentation Format

### DIFF
--- a/lib/newrelic_redis/instrumentation.rb
+++ b/lib/newrelic_redis/instrumentation.rb
@@ -5,83 +5,90 @@ require 'redis'
 #  Originally contributed by Ashley Martens of ngmoco
 #  Rewritten, reorganized, and repackaged by Evan Phoenix
 
-load_probes =
-  !NewRelic::Control.instance['disable_redis'] &&
-  ENV['NEWRELIC_ENABLE'].to_s !~ /false|off|no/i
+DependencyDetection.defer do
+  @name = :redis
 
-# load_probes checked as a post condition
-::Redis::Client.class_eval do
-
-  include NewRelic::Agent::MethodTracer
-
-  # Support older versions of Redis::Client that used the method
-  # +raw_call_command+.
-
-  call_method = 
-    ::Redis::Client.new.respond_to?(:call) ? :call : :raw_call_command
-
-  def call_with_newrelic_trace(*args, &blk)
-    if NewRelic::Agent::Instrumentation::MetricFrame.recording_web_transaction?
-      total_metric = 'Database/Redis/allWeb'
-    else
-      total_metric = 'Database/Redis/allOther'
-    end
-
-    method_name = args[0].is_a?(Array) ? args[0][0] : args[0]
-    metrics = ["Database/Redis/#{method_name.to_s.upcase}", total_metric]
-
-    self.class.trace_execution_scoped(metrics) do
-      start = Time.now
-
-      begin
-        call_without_newrelic_trace(*args, &blk)
-      ensure
-        s = NewRelic::Agent.instance.transaction_sampler
-        s.notice_nosql(args.inspect, (Time.now - start).to_f) rescue nil
-      end
-    end
+  depends_on do
+    defined?(::Redis) and not NewRelic::Control.instance['disable_redis']
   end
 
-  alias_method :call_without_newrelic_trace, call_method
-  alias_method call_method, :call_with_newrelic_trace
+  executes do
+    NewRelic::Agent.logger.debug 'Installing Redis Instrumentation'
+  end
 
-  # Older versions of Redis handle pipelining completely differently.
-  # Don't bother supporting them for now.
-  #
-  if public_method_defined? :call_pipelined
-    def call_pipelined_with_newrelic_trace(commands, *rest)
-      if NewRelic::Agent::Instrumentation::MetricFrame.recording_web_transaction?
-        total_metric = 'Database/Redis/allWeb'
-      else
-        total_metric = 'Database/Redis/allOther'
-      end
+  executes do
+    ::Redis::Client.class_eval do
+      # Support older versions of Redis::Client that used the method
+      # +raw_call_command+.
+    
+      call_method = ::Redis::Client.new.respond_to?(:call) ? :call : :raw_call_command      
 
-      # Report each command as a metric under pipelined, so the user
-      # can at least see what all the commands were. This prevents
-      # metric namespace explosion.
+      def call_with_newrelic_trace(*args, &blk)
+        if NewRelic::Agent::Instrumentation::MetricFrame.recording_web_transaction?
+          total_metric = 'Database/Redis/allWeb'
+        else
+          total_metric = 'Database/Redis/allOther'
+        end
 
-      metrics = ["Database/Redis/Pipelined", total_metric]
+        method_name = args[0].is_a?(Array) ? args[0][0] : args[0]
+        metrics = ["Database/Redis/#{method_name.to_s.upcase}", total_metric]
 
-      commands.each do |c|
-        name = c.kind_of?(Array) ? c[0] : c
-        metrics << "Database/Redis/Pipelined/#{name.to_s.upcase}"
-      end
-
-      self.class.trace_execution_scoped(metrics) do
-        start = Time.now
-
-        begin
-          call_pipelined_without_newrelic_trace commands, *rest
-        ensure
-          s = NewRelic::Agent.instance.transaction_sampler
-          s.notice_nosql(commands.inspect, (Time.now - start).to_f) rescue nil
+        self.class.trace_execution_scoped(metrics) do
+          start = Time.now
+    
+          begin
+            call_without_newrelic_trace(*args, &blk)
+          ensure
+            s = NewRelic::Agent.instance.transaction_sampler
+            s.notice_nosql(args.inspect, (Time.now - start).to_f) rescue nil
+          end
         end
       end
+
+      alias_method :call_without_newrelic_trace, call_method
+      alias_method call_method, :call_with_newrelic_trace
+    
+      # Older versions of Redis handle pipelining completely differently.
+      # Don't bother supporting them for now.
+      #
+      if public_method_defined? :call_pipelined
+        def call_pipelined_with_newrelic_trace(commands, *rest)
+          if NewRelic::Agent::Instrumentation::MetricFrame.recording_web_transaction?
+            total_metric = 'Database/Redis/allWeb'
+          else
+            total_metric = 'Database/Redis/allOther'
+          end
+    
+          # Report each command as a metric under pipelined, so the user
+          # can at least see what all the commands were. This prevents
+          # metric namespace explosion.
+    
+          metrics = ["Database/Redis/Pipelined", total_metric]
+    
+          commands.each do |c|
+            name = c.kind_of?(Array) ? c[0] : c
+            metrics << "Database/Redis/Pipelined/#{name.to_s.upcase}"
+          end
+    
+          self.class.trace_execution_scoped(metrics) do
+            start = Time.now
+    
+            begin
+              call_pipelined_without_newrelic_trace commands, *rest
+            ensure
+              s = NewRelic::Agent.instance.transaction_sampler
+              s.notice_nosql(commands.inspect, (Time.now - start).to_f) rescue nil
+            end
+          end
+        end
+    
+    
+        alias_method :call_pipelined_without_newrelic_trace, :call_pipelined
+        alias_method :call_pipelined, :call_pipelined_with_newrelic_trace
+      end
     end
-
-
-    alias_method :call_pipelined_without_newrelic_trace, :call_pipelined
-    alias_method :call_pipelined, :call_pipelined_with_newrelic_trace
   end
-end if load_probes
+
+end
+
 


### PR DESCRIPTION
Hey Evan, how are you doing? I've been having some problems with Resque and the newrelic-redis gem (undefined method trace_execution_scoped for Redis::Client) which, apparently, have to do with the use of the DependencyDetection loading mechanism. I've changed the instrumentation format to something similar to newrelic_moped and newrelic-workling. Things are working again. I did have a 'invalid gemspec' error when trying to bundle but I think that it is related to ownership issues.

```
newrelic-redis at /home/marcelo/.bundler/ruby/1.9.1/newrelic-redis-9085e7a8b550 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  [".gemtest"] are not files
```

I know this is a big commit, albeit most of it involves little change to the original method names and calls. Feel free to reject it if you think it's inadequate or that I didn't solve the problem as you'd do.

BTW, thanks for the great work :D
