### PR TITLE
Change installing instrumentation message from debug to info

### DIFF
--- a/lib/newrelic_redis/instrumentation.rb
+++ b/lib/newrelic_redis/instrumentation.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.debug 'Installing Redis Instrumentation'
+    NewRelic::Agent.logger.info 'Installing Redis Instrumentation'
   end
 
   executes do


### PR DESCRIPTION
Log as info to be consistent with other instrumentation messages. The message "Installing Redis Instrumentation" is missing among the other messages because the default log level is info.
