### PR TITLE
Update for newrelic_rpm Datastores in 3.11.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ HOE = Hoe.spec 'newrelic-redis' do
   developer 'Evan Phoenix', 'evan@phx.io'
 
   dependency "redis", "< 4.0"
-  dependency "newrelic_rpm", "~> 3.0"
+  dependency "newrelic_rpm", "~> 3.11"
 end
 
 file "#{HOE.spec.name}.gemspec" => ['Rakefile'] do |t|

--- a/newrelic-redis.gemspec
+++ b/newrelic-redis.gemspec
@@ -24,18 +24,18 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<redis>, ["< 4.0"])
-      s.add_runtime_dependency(%q<newrelic_rpm>, ["~> 3.0"])
+      s.add_runtime_dependency(%q<newrelic_rpm>, ["~> 3.11"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.10"])
       s.add_development_dependency(%q<hoe>, ["~> 2.16"])
     else
       s.add_dependency(%q<redis>, ["< 4.0"])
-      s.add_dependency(%q<newrelic_rpm>, ["~> 3.0"])
+      s.add_dependency(%q<newrelic_rpm>, ["~> 3.11"])
       s.add_dependency(%q<rdoc>, ["~> 3.10"])
       s.add_dependency(%q<hoe>, ["~> 2.16"])
     end
   else
     s.add_dependency(%q<redis>, ["< 4.0"])
-    s.add_dependency(%q<newrelic_rpm>, ["~> 3.0"])
+    s.add_dependency(%q<newrelic_rpm>, ["~> 3.11"])
     s.add_dependency(%q<rdoc>, ["~> 3.10"])
     s.add_dependency(%q<hoe>, ["~> 2.16"])
   end

--- a/test/test_newrelic_redis.rb
+++ b/test/test_newrelic_redis.rb
@@ -1,61 +1,63 @@
 require 'test/unit'
 require 'redis'
 
+require 'newrelic_rpm'
 require 'newrelic_redis/instrumentation'
 
-class TestNewRelicRedis < Test::Unit::TestCase
-  include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+DependencyDetection.detect!
 
+NewRelic::Agent.require_test_helper
+
+class TestNewRelicRedis < Test::Unit::TestCase
   PORT = 6381
   OPTIONS = {:port => PORT, :db => 15, :timeout => 0.1}
 
   def setup
-    NewRelic::Agent.manual_start
-    @engine = NewRelic::Agent.instance.stats_engine
-    @engine.clear_stats
-
-    @sampler = NewRelic::Agent.instance.transaction_sampler
-    @sampler.enable
-    @sampler.reset!
-    @sampler.start_builder
+    NewRelic::Agent.drop_buffered_data
 
     @redis = Redis.new OPTIONS
     @client = @redis.client
-
-    DependencyDetection.detect!
-  end
-
-  def teardown
-    @sampler.clear_builder
   end
 
   def assert_metrics(*m)
-    m.each do |x|
-      assert @engine.metrics.include?(x), "#{x} not in metrics"
-    end
+    assert_metrics_recorded(m)
+  end
+
+  def assert_segment_has_key(segment_name, expected)
+    sample = NewRelic::Agent.agent.transaction_sampler.tl_builder.sample
+    segment = find_segment_with_name(sample, segment_name)
+    assert_equal expected, segment.params[:key]
   end
 
   def test_call
-    @redis.hgetall "foo"
-    assert_metrics "Datastore/Redis/HGETALL", "Datastore/Redis/allOther"
+    with_config(:'transaction_tracer.record_sql' => 'raw') do
+      in_transaction do
+        @redis.hgetall "foo"
+        assert_segment_has_key "Datastore/Redis/SELECT", "[[:select, 15]]"
+        assert_segment_has_key "Datastore/Redis/HGETALL", "[[:hgetall, \"foo\"]]"
+      end
+    end
 
-    prm = @sampler.builder.current_segment.params
-    assert_equal "[[:select, 15]];\n[[:hgetall, \"foo\"]]", prm[:key]
+    assert_metrics "Datastore/Redis/HGETALL", "Datastore/Redis/allOther"
   end
 
   def test_call_pipelined
-    @redis.pipelined do
-      @redis.hgetall "foo"
-      @redis.incr "bar"
+    with_config(:'transaction_tracer.record_sql' => 'raw') do
+      in_transaction do
+        @redis.pipelined do
+          @redis.hgetall "foo"
+          @redis.incr "bar"
+        end
+
+        assert_segment_has_key "Datastore/Redis/SELECT", "[[:select, 15]]"
+        assert_segment_has_key "Datastore/Redis/Pipelined", "[[:hgetall, \"foo\"], [:incr, \"bar\"]]"
+      end
     end
 
     assert_metrics "Datastore/Redis/Pipelined",
                    "Datastore/Redis/Pipelined/HGETALL",
                    "Datastore/Redis/Pipelined/INCR",
                    "Datastore/Redis/allOther"
-
-    prm = @sampler.builder.current_segment.params
-    assert_equal "[[:select, 15]];\n[[:hgetall, \"foo\"], [:incr, \"bar\"]]", prm[:key]
   end
 
   def test_call_with_block
@@ -73,18 +75,21 @@ class TestNewRelicRedis < Test::Unit::TestCase
   end
 
   def test_obfuscated
-    NewRelic::Control.instance["transaction_tracer.record_sql"] = "obfuscated"
-    @redis.pipelined do
-      @redis.hgetall "foo"
-      @redis.incr "bar"
+    with_config(:'transaction_tracer.record_sql' => 'obfuscated') do
+      in_transaction do
+        @redis.pipelined do
+          @redis.hgetall "foo"
+          @redis.incr "bar"
+        end
+
+        assert_segment_has_key "Datastore/Redis/SELECT", "[[:select, \"?\"]]"
+        assert_segment_has_key "Datastore/Redis/Pipelined", "[[:hgetall, \"?\"], [:incr, \"?\"]]"
+      end
     end
 
     assert_metrics "Datastore/Redis/Pipelined",
                    "Datastore/Redis/Pipelined/HGETALL",
                    "Datastore/Redis/Pipelined/INCR",
                    "Datastore/Redis/allOther"
-
-    prm = @sampler.builder.current_segment.params
-    assert_equal "[[:select, \"?\"]];\n[[:hgetall, \"?\"], [:incr, \"?\"]]", prm[:key]
   end
 end


### PR DESCRIPTION
`newrelic_rpm` version 3.11.0 made some big changes to how we record "datastore" metrics to let us be more consistent between SQL and NoSQL databases through. (User-facing docs about it are at https://docs.newrelic.com/docs/apm/applications-menu/monitoring/databases-slow-queries-dashboard.)

For `newrelic-redis` to comply with that meant some significant changes to the metrics recorded--it was more than just renaming them. But we also released a new public API to make this easier, so I've made the changes myself just to be sure that they behave as expected.

As a first step I found that the tests were a bit out of sync with recent agents, so I updated them to pass properly on `newrelic_rpm` 3.10.0. Then I proceeded in a separate commit to actually do the Datastores updates.

Note that this does bump the required version of `newrelic_rpm` to 3.11.0 because it relies now on APIs that weren't around before. Clients that need a compatible `newrelic-redis` with older agents, though, can just lock prior to this rev.

Appreciate the work you've done on making this extension. It's one of the more popular gems that build on the Ruby agent, and we :sparkling_heart: that!

Addresses #19. cc @tkrajcar