### PR TITLE
Allow to use newrelic_rpm 4

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,8 @@ HOE = Hoe.spec 'newrelic-redis' do
   license "BSD"
 
   dependency "redis", "< 4.0"
-  dependency "newrelic_rpm", "~> 3.11"
+  dependency "newrelic_rpm", "~> 4.0"
+  dependency "minitest", ">= 5", :dev
 
   self.readme_file = "README.md"
 end

--- a/newrelic-redis.gemspec
+++ b/newrelic-redis.gemspec
@@ -2,41 +2,44 @@
 # stub: newrelic-redis 2.0.2 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "newrelic-redis"
+  s.name = "newrelic-redis".freeze
   s.version = "2.0.2"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["Evan Phoenix"]
-  s.date = "2015-04-08"
-  s.description = "Redis instrumentation for Newrelic."
-  s.email = ["evan@phx.io"]
-  s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.md"]
-  s.files = [".autotest", ".gemtest", "History.txt", "Manifest.txt", "README.md", "Rakefile", "lib/newrelic-redis.rb", "lib/newrelic_redis/instrumentation.rb", "lib/newrelic_redis/version.rb", "newrelic-redis.gemspec", "test/test.conf", "test/test_newrelic_redis.rb"]
-  s.homepage = "http://github.com/evanphx/newrelic-redis"
-  s.licenses = ["BSD"]
-  s.rdoc_options = ["--main", "README.md"]
-  s.rubygems_version = "2.2.2"
-  s.summary = "Redis instrumentation for Newrelic."
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Evan Phoenix".freeze]
+  s.date = "2017-05-17"
+  s.description = "Redis instrumentation for Newrelic.".freeze
+  s.email = ["evan@phx.io".freeze]
+  s.extra_rdoc_files = ["History.txt".freeze, "Manifest.txt".freeze, "README.md".freeze]
+  s.files = [".autotest".freeze, "History.txt".freeze, "Manifest.txt".freeze, "README.md".freeze, "Rakefile".freeze, "lib/newrelic-redis.rb".freeze, "lib/newrelic_redis/instrumentation.rb".freeze, "lib/newrelic_redis/version.rb".freeze, "newrelic-redis.gemspec".freeze, "test/test.conf".freeze, "test/test_newrelic_redis.rb".freeze]
+  s.homepage = "http://github.com/evanphx/newrelic-redis".freeze
+  s.licenses = ["BSD".freeze]
+  s.rdoc_options = ["--main".freeze, "README.md".freeze]
+  s.rubygems_version = "2.6.11".freeze
+  s.summary = "Redis instrumentation for Newrelic.".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<redis>, ["< 4.0"])
-      s.add_runtime_dependency(%q<newrelic_rpm>, ["~> 3.11"])
-      s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
-      s.add_development_dependency(%q<hoe>, ["~> 3.13"])
+      s.add_runtime_dependency(%q<redis>.freeze, ["< 4.0"])
+      s.add_runtime_dependency(%q<newrelic_rpm>.freeze, ["~> 4.0"])
+      s.add_development_dependency(%q<minitest>.freeze, [">= 5"])
+      s.add_development_dependency(%q<rdoc>.freeze, ["~> 4.0"])
+      s.add_development_dependency(%q<hoe>.freeze, ["~> 3.16"])
     else
-      s.add_dependency(%q<redis>, ["< 4.0"])
-      s.add_dependency(%q<newrelic_rpm>, ["~> 3.11"])
-      s.add_dependency(%q<rdoc>, ["~> 4.0"])
-      s.add_dependency(%q<hoe>, ["~> 3.13"])
+      s.add_dependency(%q<redis>.freeze, ["< 4.0"])
+      s.add_dependency(%q<newrelic_rpm>.freeze, ["~> 4.0"])
+      s.add_dependency(%q<minitest>.freeze, [">= 5"])
+      s.add_dependency(%q<rdoc>.freeze, ["~> 4.0"])
+      s.add_dependency(%q<hoe>.freeze, ["~> 3.16"])
     end
   else
-    s.add_dependency(%q<redis>, ["< 4.0"])
-    s.add_dependency(%q<newrelic_rpm>, ["~> 3.11"])
-    s.add_dependency(%q<rdoc>, ["~> 4.0"])
-    s.add_dependency(%q<hoe>, ["~> 3.13"])
+    s.add_dependency(%q<redis>.freeze, ["< 4.0"])
+    s.add_dependency(%q<newrelic_rpm>.freeze, ["~> 4.0"])
+    s.add_dependency(%q<minitest>.freeze, [">= 5"])
+    s.add_dependency(%q<rdoc>.freeze, ["~> 4.0"])
+    s.add_dependency(%q<hoe>.freeze, ["~> 3.16"])
   end
 end

--- a/test/test_newrelic_redis.rb
+++ b/test/test_newrelic_redis.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'redis'
 
 require 'newrelic_rpm'
@@ -8,7 +8,7 @@ DependencyDetection.detect!
 
 NewRelic::Agent.require_test_helper
 
-class TestNewRelicRedis < Test::Unit::TestCase
+class TestNewRelicRedis < Minitest::Test
   PORT = 6381
   OPTIONS = {:port => PORT, :db => 15, :timeout => 0.1}
 
@@ -25,7 +25,7 @@ class TestNewRelicRedis < Test::Unit::TestCase
 
   def assert_segment_has_key(segment_name, expected)
     sample = NewRelic::Agent.agent.transaction_sampler.tl_builder.sample
-    segment = find_segment_with_name(sample, segment_name)
+    segment = find_node_with_name(sample, segment_name)
     assert_equal expected, segment.params[:statement]
   end
 


### PR DESCRIPTION
newrelic_rpm released the version 4. I updated the gemspec and the test so a new version of this gem can work with the newest version of the agent.

@evanphx could you merge it and release?